### PR TITLE
GIT-3: Use bare cloning

### DIFF
--- a/src/main/java/org/xwiki/git/GitManager.java
+++ b/src/main/java/org/xwiki/git/GitManager.java
@@ -76,12 +76,12 @@ public interface GitManager
      * @param repositoryURI the URI to the Git repository to clone (eg "git://github.com/xwiki/xwiki-commons.git")
      * @param localDirectoryName the name of the directory where the Git repository will be cloned (this directory is
      *        relative to the permanent directory
-     * @param cloneCommand the clone settings used as CloneCommand object
+     * @param cloneCommand the CloneCommand used for clone options
      * @return the cloned Repository instance
      * @since 9.10
      */
     @Unstable
-    default Repository getRepositoryBare(String repositoryURI, String localDirectoryName, CloneCommand cloneCommand)
+    default Repository getRepository(String repositoryURI, String localDirectoryName, CloneCommand cloneCommand)
     {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/org/xwiki/git/GitManager.java
+++ b/src/main/java/org/xwiki/git/GitManager.java
@@ -23,6 +23,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Repository;
 import org.gitective.core.stat.UserCommitActivity;
@@ -69,20 +70,18 @@ public interface GitManager
     }
 
     /**
-     * Clone a private Git repository as Bare using the credentials provided by user and store it locally in the
+     * Clone a Git repository as Bare using the CloneCommand provided by user and store it locally in the
      * XWiki Permanent directory. If the repository is already cloned, no action is done.
      *
      * @param repositoryURI the URI to the Git repository to clone (eg "git://github.com/xwiki/xwiki-commons.git")
      * @param localDirectoryName the name of the directory where the Git repository will be cloned (this directory is
      *        relative to the permanent directory
-     * @param username the username of the Git user
-     * @param accessCode the password or OAuth or personal access token that authenticates with the Git user
+     * @param cloneCommand the clone settings used as CloneCommand object
      * @return the cloned Repository instance
      * @since 9.10
      */
     @Unstable
-    default Repository getRepositoryBare(String repositoryURI, String localDirectoryName, String username,
-        String accessCode)
+    default Repository getRepositoryBare(String repositoryURI, String localDirectoryName, CloneCommand cloneCommand)
     {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/org/xwiki/git/GitManager.java
+++ b/src/main/java/org/xwiki/git/GitManager.java
@@ -69,6 +69,25 @@ public interface GitManager
     }
 
     /**
+     * Clone a private Git repository as Bare using the credentials provided by user and store it locally in the
+     * XWiki Permanent directory. If the repository is already cloned, no action is done.
+     *
+     * @param repositoryURI the URI to the Git repository to clone (eg "git://github.com/xwiki/xwiki-commons.git")
+     * @param localDirectoryName the name of the directory where the Git repository will be cloned (this directory is
+     *        relative to the permanent directory
+     * @param username the username of the Git user
+     * @param accessCode the password or OAuth or personal access token that authenticates with the Git user
+     * @return the cloned Repository instance
+     * @since 9.10
+     */
+    @Unstable
+    default Repository getRepositoryBare(String repositoryURI, String localDirectoryName, String username,
+        String accessCode)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Find all authors who have ever committed code in the passed repositories.
      *
      * @param repositories the list of repositories in which to look for authors

--- a/src/main/java/org/xwiki/git/internal/DefaultGitManager.java
+++ b/src/main/java/org/xwiki/git/internal/DefaultGitManager.java
@@ -69,7 +69,8 @@ public class DefaultGitManager implements GitManager
     @Inject
     private Logger logger;
 
-    private Repository getGitRepository(String repositoryURI, String localDirectoryName, CloneCommand cloneCommand)
+    @Override
+    public Repository getRepository(String repositoryURI, String localDirectoryName, CloneCommand cloneCommand)
     {
         Repository repository;
 
@@ -106,7 +107,7 @@ public class DefaultGitManager implements GitManager
     {
         // Simple CloneCommand with default settings
         CloneCommand cloneCommand = Git.cloneRepository();
-        return getGitRepository(repositoryURI, localDirectoryName, cloneCommand);
+        return getRepository(repositoryURI, localDirectoryName, cloneCommand);
     }
 
     @Override
@@ -115,15 +116,7 @@ public class DefaultGitManager implements GitManager
         // CloneCommand with basic authentication
         CloneCommand cloneCommand = Git.cloneRepository();
         cloneCommand.setCredentialsProvider(new UsernamePasswordCredentialsProvider(username, accessCode));
-        return getGitRepository(repositoryURI, localDirectoryName, cloneCommand);
-    }
-
-    @Override
-    public Repository getRepositoryBare(String repositoryURI, String localDirectoryName, CloneCommand cloneCommand)
-    {
-        // CloneCommand with bare settings
-        cloneCommand.setBare(true);
-        return getGitRepository(repositoryURI, localDirectoryName, cloneCommand);
+        return getRepository(repositoryURI, localDirectoryName, cloneCommand);
     }
 
     @Override

--- a/src/main/java/org/xwiki/git/internal/DefaultGitManager.java
+++ b/src/main/java/org/xwiki/git/internal/DefaultGitManager.java
@@ -121,9 +121,6 @@ public class DefaultGitManager implements GitManager
     @Override
     public Repository getRepositoryBare(String repositoryURI, String localDirectoryName, CloneCommand cloneCommand)
     {
-        if (cloneCommand == null) {
-            cloneCommand = Git.cloneRepository();
-        }
         // CloneCommand with bare settings
         cloneCommand.setBare(true);
         return getGitRepository(repositoryURI, localDirectoryName, cloneCommand);

--- a/src/main/java/org/xwiki/git/script/GitScriptService.java
+++ b/src/main/java/org/xwiki/git/script/GitScriptService.java
@@ -28,8 +28,11 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.eclipse.jgit.api.CloneCommand;
+import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.gitective.core.stat.UserCommitActivity;
 import org.joda.time.DateTime;
 import org.xwiki.component.annotation.Component;
@@ -112,7 +115,8 @@ public class GitScriptService implements ScriptService
     @Unstable
     public Repository getRepositoryBare(String repositoryURI, String localDirectoryName)
     {
-        return this.gitManager.getRepositoryBare(repositoryURI, localDirectoryName, null, null);
+        CloneCommand cloneCommand = Git.cloneRepository();
+        return this.gitManager.getRepositoryBare(repositoryURI, localDirectoryName, cloneCommand);
     }
 
     /**
@@ -131,7 +135,9 @@ public class GitScriptService implements ScriptService
     public Repository getRepositoryBare(String repositoryURI, String localDirectoryName, String username,
         String accessCode)
     {
-        return this.gitManager.getRepositoryBare(repositoryURI, localDirectoryName, username, accessCode);
+        CloneCommand cloneCommand = Git.cloneRepository();
+        cloneCommand.setCredentialsProvider(new UsernamePasswordCredentialsProvider(username, accessCode));
+        return this.gitManager.getRepositoryBare(repositoryURI, localDirectoryName, cloneCommand);
     }
 
     /**

--- a/src/main/java/org/xwiki/git/script/GitScriptService.java
+++ b/src/main/java/org/xwiki/git/script/GitScriptService.java
@@ -32,7 +32,6 @@ import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.gitective.core.stat.UserCommitActivity;
 import org.joda.time.DateTime;
 import org.xwiki.component.annotation.Component;
@@ -84,7 +83,7 @@ public class GitScriptService implements ScriptService
     }
 
     /**
-     * Clone a Private Git repository using the credentials provided by user and store it locally in the
+     * Clone a protected Git repository by using the credentials provided by user and store it locally in the
      * XWiki Permanent directory. If the repository is already cloned, no action is done.
      *
      * @param repositoryURI the URI to the Git repository to clone (eg "git://github.com/xwiki/xwiki-commons.git")
@@ -103,41 +102,32 @@ public class GitScriptService implements ScriptService
     }
 
     /**
-     * Clone a Git repository as Bare by storing it locally in the XWiki Permanent directory. If the repository is
-     * already cloned, no action is done.
-     *
-     * @param repositoryURI the URI to the Git repository to clone (eg "git://github.com/xwiki/xwiki-commons.git")
-     * @param localDirectoryName the name of the directory where the Git repository will be cloned (this directory is
-     *        relative to the permanent directory
-     * @return the cloned Repository instance
-     * @since 9.10
-     */
-    @Unstable
-    public Repository getRepositoryBare(String repositoryURI, String localDirectoryName)
-    {
-        CloneCommand cloneCommand = Git.cloneRepository();
-        return this.gitManager.getRepositoryBare(repositoryURI, localDirectoryName, cloneCommand);
-    }
-
-    /**
-     * Clone a private Git repository as Bare using the credentials provided by user and store it locally in the
+     * Clone a protected Git repository by using the credentials provided by user and store it locally in the
      * XWiki Permanent directory. If the repository is already cloned, no action is done.
      *
      * @param repositoryURI the URI to the Git repository to clone (eg "git://github.com/xwiki/xwiki-commons.git")
      * @param localDirectoryName the name of the directory where the Git repository will be cloned (this directory is
      *        relative to the permanent directory
-     * @param username the username of the Git user
-     * @param accessCode the password or OAuth or personal access token that authenticates with the Git user
+     * @param cloneCommand the CloneCommand used for clone options
      * @return the cloned Repository instance
+     * @since 9.9
+     */
+    @Unstable
+    public Repository getRepository(String repositoryURI, String localDirectoryName, CloneCommand cloneCommand)
+    {
+        return this.gitManager.getRepository(repositoryURI, localDirectoryName, cloneCommand);
+    }
+
+    /**
+     * Create a CloneCommand object for custom clone options.
+     *
+     * @return the CloneCommand instance
      * @since 9.10
      */
     @Unstable
-    public Repository getRepositoryBare(String repositoryURI, String localDirectoryName, String username,
-        String accessCode)
+    public CloneCommand createCloneCommand()
     {
-        CloneCommand cloneCommand = Git.cloneRepository();
-        cloneCommand.setCredentialsProvider(new UsernamePasswordCredentialsProvider(username, accessCode));
-        return this.gitManager.getRepositoryBare(repositoryURI, localDirectoryName, cloneCommand);
+        return Git.cloneRepository();
     }
 
     /**

--- a/src/main/java/org/xwiki/git/script/GitScriptService.java
+++ b/src/main/java/org/xwiki/git/script/GitScriptService.java
@@ -100,6 +100,41 @@ public class GitScriptService implements ScriptService
     }
 
     /**
+     * Clone a Git repository as Bare by storing it locally in the XWiki Permanent directory. If the repository is
+     * already cloned, no action is done.
+     *
+     * @param repositoryURI the URI to the Git repository to clone (eg "git://github.com/xwiki/xwiki-commons.git")
+     * @param localDirectoryName the name of the directory where the Git repository will be cloned (this directory is
+     *        relative to the permanent directory
+     * @return the cloned Repository instance
+     * @since 9.10
+     */
+    @Unstable
+    public Repository getRepositoryBare(String repositoryURI, String localDirectoryName)
+    {
+        return this.gitManager.getRepositoryBare(repositoryURI, localDirectoryName, null, null);
+    }
+
+    /**
+     * Clone a private Git repository as Bare using the credentials provided by user and store it locally in the
+     * XWiki Permanent directory. If the repository is already cloned, no action is done.
+     *
+     * @param repositoryURI the URI to the Git repository to clone (eg "git://github.com/xwiki/xwiki-commons.git")
+     * @param localDirectoryName the name of the directory where the Git repository will be cloned (this directory is
+     *        relative to the permanent directory
+     * @param username the username of the Git user
+     * @param accessCode the password or OAuth or personal access token that authenticates with the Git user
+     * @return the cloned Repository instance
+     * @since 9.10
+     */
+    @Unstable
+    public Repository getRepositoryBare(String repositoryURI, String localDirectoryName, String username,
+        String accessCode)
+    {
+        return this.gitManager.getRepositoryBare(repositoryURI, localDirectoryName, username, accessCode);
+    }
+
+    /**
      * Find all authors who have ever committed code in the passed repository.
      *
      * @param repositories the list of repositories in which to look for authors

--- a/src/test/java/org/xwiki/git/internal/DefaultGitManagerTest.java
+++ b/src/test/java/org/xwiki/git/internal/DefaultGitManagerTest.java
@@ -26,20 +26,22 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
-import org.eclipse.jgit.errors.NoWorkTreeException;
+import org.eclipse.jgit.api.CloneCommand;
+import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.junit.TestRepository;
 import org.eclipse.jgit.junit.http.AppServer;
 import org.eclipse.jgit.junit.http.HttpTestCase;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.transport.URIish;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.xwiki.test.mockito.MockitoComponentMockingRule;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -112,20 +114,17 @@ public class DefaultGitManagerTest extends HttpTestCase
     }
 
     @Test
-    public void getRepositoryBareWithCredentials() throws Exception
+    public void getRepositoryBareAndCheckBare() throws Exception
     {
         String repositoryURI = this.serverURI.toASCIIString();
         String localPath = this.tmpFolder.newFolder("getRepositoryBareWithCredentials").toString();
+        CloneCommand cloneCommand = Git.cloneRepository();
+        cloneCommand.setCredentialsProvider(new UsernamePasswordCredentialsProvider(AppServer.username,
+            AppServer.password));
         Repository repository = this.mocker.getComponentUnderTest().getRepositoryBare(repositoryURI, localPath,
-            AppServer.username, AppServer.password);
+            cloneCommand);
         assertNotNull(repository);
-
-        try {
-            assertNull(repository.getWorkTree());
-            fail("Expected NoWorkTreeException");
-        } catch (NoWorkTreeException expected) {
-            assertTrue(ExceptionUtils.getRootCauseMessage(expected).matches("NoWorkTreeException: .*"));
-        }
+        assertEquals(true, repository.isBare());
     }
 
     /**

--- a/src/test/java/org/xwiki/git/internal/DefaultGitManagerTest.java
+++ b/src/test/java/org/xwiki/git/internal/DefaultGitManagerTest.java
@@ -114,14 +114,15 @@ public class DefaultGitManagerTest extends HttpTestCase
     }
 
     @Test
-    public void getRepositoryBareAndCheckBare() throws Exception
+    public void getRepositoryBare() throws Exception
     {
         String repositoryURI = this.serverURI.toASCIIString();
         String localPath = this.tmpFolder.newFolder("getRepositoryBareWithCredentials").toString();
         CloneCommand cloneCommand = Git.cloneRepository();
         cloneCommand.setCredentialsProvider(new UsernamePasswordCredentialsProvider(AppServer.username,
             AppServer.password));
-        Repository repository = this.mocker.getComponentUnderTest().getRepositoryBare(repositoryURI, localPath,
+        cloneCommand.setBare(true);
+        Repository repository = this.mocker.getComponentUnderTest().getRepository(repositoryURI, localPath,
             cloneCommand);
         assertNotNull(repository);
         assertEquals(true, repository.isBare());

--- a/src/test/java/org/xwiki/git/internal/DefaultGitManagerTest.java
+++ b/src/test/java/org/xwiki/git/internal/DefaultGitManagerTest.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jgit.errors.NoWorkTreeException;
 import org.eclipse.jgit.junit.TestRepository;
 import org.eclipse.jgit.junit.http.AppServer;
 import org.eclipse.jgit.junit.http.HttpTestCase;
@@ -38,6 +39,7 @@ import org.junit.rules.TemporaryFolder;
 import org.xwiki.test.mockito.MockitoComponentMockingRule;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -106,6 +108,23 @@ public class DefaultGitManagerTest extends HttpTestCase
             fail("An exception should have been thrown");
         } catch (Exception expected) {
             assertTrue(ExceptionUtils.getRootCauseMessage(expected).matches("TransportException: .*: not authorized"));
+        }
+    }
+
+    @Test
+    public void getRepositoryBareWithCredentials() throws Exception
+    {
+        String repositoryURI = this.serverURI.toASCIIString();
+        String localPath = this.tmpFolder.newFolder("getRepositoryBareWithCredentials").toString();
+        Repository repository = this.mocker.getComponentUnderTest().getRepositoryBare(repositoryURI, localPath,
+            AppServer.username, AppServer.password);
+        assertNotNull(repository);
+
+        try {
+            assertNull(repository.getWorkTree());
+            fail("Expected NoWorkTreeException");
+        } catch (NoWorkTreeException expected) {
+            assertTrue(ExceptionUtils.getRootCauseMessage(expected).matches("NoWorkTreeException: .*"));
         }
     }
 

--- a/src/test/java/org/xwiki/git/script/GitScriptServiceTest.java
+++ b/src/test/java/org/xwiki/git/script/GitScriptServiceTest.java
@@ -23,7 +23,9 @@ import java.io.File;
 import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
+import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.errors.NoWorkTreeException;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Repository;
 import org.gitective.core.stat.UserCommitActivity;
@@ -88,7 +90,7 @@ public class GitScriptServiceTest
     }
 
     @Test
-    public void getRepositoryAndCountCommits() throws Exception
+    public void getRepositoryWithCredentialsAndCountCommits() throws Exception
     {
         GitScriptService service = this.componentManager.getInstance(ScriptService.class, "git");
         Repository repository = service.getRepository(this.testRepository.getAbsolutePath(), TEST_REPO_CLONED,
@@ -103,11 +105,13 @@ public class GitScriptServiceTest
     }
 
     @Test
-    public void getRepositoryBareAndCheckBranch() throws Exception
+    public void getRepositoryBare() throws Exception
     {
         GitScriptService service = this.componentManager.getInstance(ScriptService.class, "git");
-        Repository repository = service.getRepositoryBare(this.testRepository.getAbsolutePath(), TEST_REPO_CLONED,
-            "test author", "TestAccessCode");
+        CloneCommand cloneCommand = service.createCloneCommand();
+        cloneCommand.setBare(true);
+        Repository repository = service.getRepository(this.testRepository.getAbsolutePath(), TEST_REPO_CLONED,
+            cloneCommand);
         assertEquals(true, repository.isBare());
         // Now check branch
         assertEquals("master", repository.getBranch());

--- a/src/test/java/org/xwiki/git/script/GitScriptServiceTest.java
+++ b/src/test/java/org/xwiki/git/script/GitScriptServiceTest.java
@@ -75,36 +75,25 @@ public class GitScriptServiceTest
             new PersonIdent("test committer", "committer@doe.com"), "first commit");
     }
 
-    private void getGitRepositoryAndFindAuthors(boolean useBare) throws Exception
+    @Test
+    public void getRepositoryAndFindAuthors() throws Exception
     {
         GitScriptService service = this.componentManager.getInstance(ScriptService.class, "git");
-        Repository repository = useBare
-            ? service.getRepositoryBare(this.testRepository.getAbsolutePath(), TEST_REPO_CLONED)
-            : service.getRepository(this.testRepository.getAbsolutePath(), TEST_REPO_CLONED);
-        if (useBare) {
-            assertEquals(true, repository.isBare());
-        } else {
-            assertEquals(true, new Git(repository).pull().call().isSuccessful());
-        }
+        Repository repository = service.getRepository(this.testRepository.getAbsolutePath(), TEST_REPO_CLONED);
+        assertEquals(true, new Git(repository).pull().call().isSuccessful());
         // Now find authors
         Set<PersonIdent> authors = service.findAuthors(repository);
         assertEquals(1, authors.size());
         assertEquals("test author", authors.iterator().next().getName());
     }
 
-    private void getGitRepositoryAndCountCommits(boolean useBare) throws Exception
+    @Test
+    public void getRepositoryAndCountCommits() throws Exception
     {
         GitScriptService service = this.componentManager.getInstance(ScriptService.class, "git");
-        Repository repository = useBare
-            ? service.getRepositoryBare(this.testRepository.getAbsolutePath(), TEST_REPO_CLONED,
-            "test author", "TestAccessCode")
-            : service.getRepository(this.testRepository.getAbsolutePath(), TEST_REPO_CLONED,
+        Repository repository = service.getRepository(this.testRepository.getAbsolutePath(), TEST_REPO_CLONED,
             "test author", "TestAccessCode");
-        if (useBare) {
-            assertEquals(true, repository.isBare());
-        } else {
-            assertEquals(true, new Git(repository).pull().call().isSuccessful());
-        }
+        assertEquals(true, new Git(repository).pull().call().isSuccessful());
         // Now count commits
         UserCommitActivity[] commits = service.countAuthorCommits(1, repository);
         // 1 author
@@ -114,26 +103,13 @@ public class GitScriptServiceTest
     }
 
     @Test
-    public void getRepositoryAndFindAuthors() throws Exception
+    public void getRepositoryBareAndCheckBranch() throws Exception
     {
-        getGitRepositoryAndFindAuthors(false);
-    }
-
-    @Test
-    public void getRepositoryAndCountCommits() throws Exception
-    {
-        getGitRepositoryAndCountCommits(false);
-    }
-
-    @Test
-    public void getRepositoryBareAndFindAuthors() throws Exception
-    {
-        getGitRepositoryAndFindAuthors(true);
-    }
-
-    @Test
-    public void getRepositoryBareAndCountCommits() throws Exception
-    {
-        getGitRepositoryAndCountCommits(true);
+        GitScriptService service = this.componentManager.getInstance(ScriptService.class, "git");
+        Repository repository = service.getRepositoryBare(this.testRepository.getAbsolutePath(), TEST_REPO_CLONED,
+            "test author", "TestAccessCode");
+        assertEquals(true, repository.isBare());
+        // Now check branch
+        assertEquals("master", repository.getBranch());
     }
 }


### PR DESCRIPTION
[Issue link](https://jira.xwiki.org/browse/GIT-3)
Hi, I know this PR is late as I was catching up with my university assignments.

Changes are explained in commit messages.
Coverage is 0.91+.
Extension built and tested on XWiki build.

Summary:
Added `getRepositoryBare` to get and save the repositories as Bare in local drive.
1. Introduce `getRepositoryBare` method in the interface and implement it in `DefaultGitManager`.
2. Introduce 2 `getRepositoryBare`, 1 for authentication, 2 for without authentication in `GitScriptService`.
3. Test bare repository by checking WorkTree in `DefaultGitManagerTest`.
4. Test use cases by counting commits and finding authors in `GitScriptServiceTest`.

Thanks.