### PR TITLE
GIT-8: Fix service tests and javadoc (Invalid)

### DIFF
--- a/src/main/java/org/xwiki/git/GitManager.java
+++ b/src/main/java/org/xwiki/git/GitManager.java
@@ -51,7 +51,7 @@ public interface GitManager
     Repository getRepository(String repositoryURI, String localDirectoryName);
 
     /**
-     * Clone a Private Git repository using the credentials provided by user and store it locally in the
+     * Clone a protected Git repository by using the credentials provided by user and store it locally in the
      * XWiki Permanent directory. If the repository is already cloned, no action is done.
      *
      * @param repositoryURI the URI to the Git repository to clone (eg "git://github.com/xwiki/xwiki-commons.git")
@@ -70,7 +70,7 @@ public interface GitManager
     }
 
     /**
-     * Clone a Git repository as Bare using the CloneCommand provided by user and store it locally in the
+     * Clone a Git repository using the CloneCommand provided by user and store it locally in the
      * XWiki Permanent directory. If the repository is already cloned, no action is done.
      *
      * @param repositoryURI the URI to the Git repository to clone (eg "git://github.com/xwiki/xwiki-commons.git")

--- a/src/main/java/org/xwiki/git/script/GitScriptService.java
+++ b/src/main/java/org/xwiki/git/script/GitScriptService.java
@@ -102,7 +102,7 @@ public class GitScriptService implements ScriptService
     }
 
     /**
-     * Clone a protected Git repository by using the credentials provided by user and store it locally in the
+     * Clone a Git repository using the CloneCommand provided by user and store it locally in the
      * XWiki Permanent directory. If the repository is already cloned, no action is done.
      *
      * @param repositoryURI the URI to the Git repository to clone (eg "git://github.com/xwiki/xwiki-commons.git")
@@ -110,7 +110,7 @@ public class GitScriptService implements ScriptService
      *        relative to the permanent directory
      * @param cloneCommand the CloneCommand used for clone options
      * @return the cloned Repository instance
-     * @since 9.9
+     * @since 9.10
      */
     @Unstable
     public Repository getRepository(String repositoryURI, String localDirectoryName, CloneCommand cloneCommand)

--- a/src/test/java/org/xwiki/git/script/GitScriptServiceTest.java
+++ b/src/test/java/org/xwiki/git/script/GitScriptServiceTest.java
@@ -30,6 +30,7 @@ import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Repository;
 import org.gitective.core.stat.UserCommitActivity;
 import org.junit.*;
+import org.junit.rules.TemporaryFolder;
 import org.xwiki.environment.Environment;
 import org.xwiki.environment.internal.StandardEnvironment;
 import org.xwiki.git.GitHelper;
@@ -54,6 +55,8 @@ public class GitScriptServiceTest
 
     @Rule
     public ComponentManagerRule componentManager = new ComponentManagerRule();
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
 
     private File testRepository;
 
@@ -81,7 +84,8 @@ public class GitScriptServiceTest
     public void getRepositoryAndFindAuthors() throws Exception
     {
         GitScriptService service = this.componentManager.getInstance(ScriptService.class, "git");
-        Repository repository = service.getRepository(this.testRepository.getAbsolutePath(), TEST_REPO_CLONED);
+        String localPath = this.tmpFolder.newFolder(TEST_REPO_CLONED).toString();
+        Repository repository = service.getRepository(this.testRepository.getAbsolutePath(), localPath);
         assertEquals(true, new Git(repository).pull().call().isSuccessful());
         // Now find authors
         Set<PersonIdent> authors = service.findAuthors(repository);
@@ -93,7 +97,8 @@ public class GitScriptServiceTest
     public void getRepositoryWithCredentialsAndCountCommits() throws Exception
     {
         GitScriptService service = this.componentManager.getInstance(ScriptService.class, "git");
-        Repository repository = service.getRepository(this.testRepository.getAbsolutePath(), TEST_REPO_CLONED,
+        String localPath = this.tmpFolder.newFolder(TEST_REPO_CLONED).toString();
+        Repository repository = service.getRepository(this.testRepository.getAbsolutePath(), localPath,
             "test author", "TestAccessCode");
         assertEquals(true, new Git(repository).pull().call().isSuccessful());
         // Now count commits
@@ -110,7 +115,8 @@ public class GitScriptServiceTest
         GitScriptService service = this.componentManager.getInstance(ScriptService.class, "git");
         CloneCommand cloneCommand = service.createCloneCommand();
         cloneCommand.setBare(true);
-        Repository repository = service.getRepository(this.testRepository.getAbsolutePath(), TEST_REPO_CLONED,
+        String localPath = this.tmpFolder.newFolder(TEST_REPO_CLONED).toString();
+        Repository repository = service.getRepository(this.testRepository.getAbsolutePath(), localPath,
             cloneCommand);
         assertEquals(true, repository.isBare());
         // Now check branch


### PR DESCRIPTION
Includes `TemporaryFolder` rule usage in `GitScriptServiceTest` and some minor javadoc improvements.

Edit: Invalid PR for Invalid issue.