### PR TITLE
GIT-3: Use bare cloning

### DIFF
--- a/src/test/java/org/xwiki/git/internal/DefaultGitManagerTest.java
+++ b/src/test/java/org/xwiki/git/internal/DefaultGitManagerTest.java
@@ -38,6 +38,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.xwiki.environment.Environment;
+import org.xwiki.environment.internal.StandardEnvironment;
+import org.xwiki.test.annotation.AllComponents;
 import org.xwiki.test.mockito.MockitoComponentMockingRule;
 
 import static org.junit.Assert.assertEquals;
@@ -51,6 +54,7 @@ import static org.junit.Assert.fail;
  * @version $Id$
  * @since 9.9
  */
+@AllComponents
 public class DefaultGitManagerTest extends HttpTestCase
 {
     @Rule
@@ -68,6 +72,10 @@ public class DefaultGitManagerTest extends HttpTestCase
     public void setUp() throws Exception
     {
         super.setUp();
+
+        // Configure permanent directory to be the temporary directory
+        StandardEnvironment environment = this.mocker.getInstance(Environment.class);
+        environment.setPermanentDirectory(environment.getTemporaryDirectory());
 
         // Create a repository on the server.
         this.remoteRepository = createTestRepository();

--- a/src/test/java/org/xwiki/git/script/GitScriptServiceTest.java
+++ b/src/test/java/org/xwiki/git/script/GitScriptServiceTest.java
@@ -25,12 +25,10 @@ import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.errors.NoWorkTreeException;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Repository;
 import org.gitective.core.stat.UserCommitActivity;
 import org.junit.*;
-import org.junit.rules.TemporaryFolder;
 import org.xwiki.environment.Environment;
 import org.xwiki.environment.internal.StandardEnvironment;
 import org.xwiki.git.GitHelper;
@@ -55,8 +53,6 @@ public class GitScriptServiceTest
 
     @Rule
     public ComponentManagerRule componentManager = new ComponentManagerRule();
-    @Rule
-    public TemporaryFolder tmpFolder = new TemporaryFolder();
 
     private File testRepository;
 
@@ -84,8 +80,7 @@ public class GitScriptServiceTest
     public void getRepositoryAndFindAuthors() throws Exception
     {
         GitScriptService service = this.componentManager.getInstance(ScriptService.class, "git");
-        String localPath = this.tmpFolder.newFolder(TEST_REPO_CLONED).toString();
-        Repository repository = service.getRepository(this.testRepository.getAbsolutePath(), localPath);
+        Repository repository = service.getRepository(this.testRepository.getAbsolutePath(), TEST_REPO_CLONED);
         assertEquals(true, new Git(repository).pull().call().isSuccessful());
         // Now find authors
         Set<PersonIdent> authors = service.findAuthors(repository);
@@ -97,8 +92,7 @@ public class GitScriptServiceTest
     public void getRepositoryWithCredentialsAndCountCommits() throws Exception
     {
         GitScriptService service = this.componentManager.getInstance(ScriptService.class, "git");
-        String localPath = this.tmpFolder.newFolder(TEST_REPO_CLONED).toString();
-        Repository repository = service.getRepository(this.testRepository.getAbsolutePath(), localPath,
+        Repository repository = service.getRepository(this.testRepository.getAbsolutePath(), TEST_REPO_CLONED,
             "test author", "TestAccessCode");
         assertEquals(true, new Git(repository).pull().call().isSuccessful());
         // Now count commits
@@ -115,8 +109,7 @@ public class GitScriptServiceTest
         GitScriptService service = this.componentManager.getInstance(ScriptService.class, "git");
         CloneCommand cloneCommand = service.createCloneCommand();
         cloneCommand.setBare(true);
-        String localPath = this.tmpFolder.newFolder(TEST_REPO_CLONED).toString();
-        Repository repository = service.getRepository(this.testRepository.getAbsolutePath(), localPath,
+        Repository repository = service.getRepository(this.testRepository.getAbsolutePath(), TEST_REPO_CLONED,
             cloneCommand);
         assertEquals(true, repository.isBare());
         // Now check branch


### PR DESCRIPTION
Fixed environment working directory in `DefaultGitManagerTest`.
The issue of `git` folder created in root was not due to `GitScriptServiceTest` not using [TemporaryFolder rule](https://github.com/xwiki-contrib/api-git/pull/5#issuecomment-633219428) but  was due to no environment temporary path specified in `DefaultGitManagerTest`. So, I removed the extra added rule from `GitScriptServiceTest` from the previous PR.
And some minor imports fix.

Let me know if this is wrong. Thanks.